### PR TITLE
Preparation for release v2.0.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: yarn
       - run: yarn install && yarn test && yarn build

--- a/.github/workflows/check_files.yml
+++ b/.github/workflows/check_files.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: yarn
       - run: yarn install && yarn test && yarn build
       - name: Check File Existence

--- a/README.md
+++ b/README.md
@@ -88,6 +88,12 @@ git commit -m "chore: update dist"
 yarn release
 ```
 
+> **Troubleshooting:** If you get `ERROR No upstream configured for current branch`, your branch has no upstream set. Fix it by pushing with:
+> ```sh
+> git push --set-upstream origin <branch-name>
+> ```
+> Then run `yarn release` again.
+
 This command:
 1. Reads all files in `fragments/` via `news-fragments` and appends them to [CHANGELOG.md](CHANGELOG.md)
 2. Bumps the `version` field in `package.json` via `@release-it/bumper`

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The following example [workflow step](https://help.github.com/en/actions/configu
 
 ```yml
 - name: 'Check File Existence'
-  uses: thebinaryfelix/check-file-existence-action@v1
+  uses: thebinaryfelix/check-file-existence-action@vX.X.X # check the latest release
   with:
     files: 'package.json, index.ts, README.md, *.txt'
 ```
@@ -43,11 +43,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
 
       - name: Check file existence
         id: check_files
-        uses: thebinaryfelix/check-file-existence-action@v1
+        uses: thebinaryfelix/check-file-existence-action@vX.X.X # check the latest release
         with:
           files: 'package.json, LICENSE, README.md'
 
@@ -56,6 +56,56 @@ jobs:
         # Only runs if all of the files exist
         run: echo "All files exist!"
 ```
+
+# Releasing a New Version
+
+> This process is performed locally by the maintainer.
+
+## Prerequisites
+
+- You are on the `main` branch with a clean working tree
+- All PRs to be included in the release have been merged
+- Each merged PR included a changelog fragment in `fragments/` (encouraged, but not enforced by CI)
+
+## Steps
+
+### Step 1 - Build the distribution
+
+```sh
+yarn build
+```
+
+This compiles the TypeScript source and bundles it into `dist/index.js`, which is the artifact the action executes at runtime. Commit the updated `dist/` if it changed:
+
+```sh
+git add dist/
+git commit -m "chore: update dist"
+```
+
+### Step 2 - Run the release command
+
+```sh
+yarn release
+```
+
+This command:
+1. Reads all files in `fragments/` via `news-fragments` and appends them to [CHANGELOG.md](CHANGELOG.md)
+2. Bumps the `version` field in `package.json` via `@release-it/bumper`
+3. Creates a release commit and a git tag (e.g. `v1.2.0`)
+4. Pushes the commit and tag to `main`
+
+> `HUSKY=0` is set internally in the script to skip git hooks during the automated release commit, preventing `commitlint` from blocking it.
+
+### Step 3 - Update the major version tag (optional)
+
+If the release includes breaking changes, update the floating major tag (e.g. `v1`) to point to the new commit:
+
+```sh
+git tag -fa v1 -m "Update v1 tag"
+git push origin v1 --force
+```
+
+---
 
 # Contribute
 

--- a/action.yml
+++ b/action.yml
@@ -11,11 +11,11 @@ inputs:
   follow_symlinks:
     description: 'Whether to follow symbolic links.'
     required: false
-    default: true
+    default: 'true'
   ignore_case:
-    description: 'Performe a case insentivive match.'
+    description: 'Perform a case-insensitive match.'
     required: false
-    default: false
+    default: 'true'
 outputs:
   exists:
     description: 'Whether the informed file(s) exists or not.'

--- a/fragments/1774273374631.bugfix
+++ b/fragments/1774273374631.bugfix
@@ -1,0 +1,1 @@
+Fix `ignore_case` default value in action.yml from `false` to `true` to match documented behaviour. Fix `follow_symlinks` and `ignore_case` default values from booleans to strings as required by the GitHub Actions schema. Fix typo in `ignore_case` input description.

--- a/fragments/1774273397462.doc
+++ b/fragments/1774273397462.doc
@@ -1,0 +1,1 @@
+Add "Releasing a New Version" section to README with step-by-step instructions for the local release process, including build, yarn release, and optional major tag update. Update action usage examples to use a versioned placeholder instead of a hardcoded tag.

--- a/fragments/1774273397463.misc
+++ b/fragments/1774273397463.misc
@@ -1,0 +1,1 @@
+Upgrade actions/checkout from v1 to v4 and actions/setup-node from v3 to v4 in CI workflows. Update Node.js version from 22 to 24 across all workflows to match the action runtime. Update action.yml runtime from node20 to node24.

--- a/fragments/1774273397464.misc
+++ b/fragments/1774273397464.misc
@@ -1,0 +1,1 @@
+Add missing unit tests for checkFileExistence function covering: getBooleanInput called with correct input names, glob resolution with and without files, error rejection, and nocase/follow options correctly passed to glob. Remove exclude of test files from tsconfig.json so the TypeScript language server resolves path aliases in test files.

--- a/src/utils/checkFileExistence/checkFileExistence.test.ts
+++ b/src/utils/checkFileExistence/checkFileExistence.test.ts
@@ -1,8 +1,88 @@
-import { globResolution } from './checkFileExistence'
+import glob from 'glob'
 
+import { Inputs } from '~/@enums'
+
+import { getBooleanInput } from '../coreActions'
+import { checkFileExistence, globResolution } from './checkFileExistence'
+
+jest.mock('glob')
 jest.mock('../coreActions', () => ({
   getBooleanInput: jest.fn().mockReturnValue(false),
 }))
+
+const mockedGlob = jest.mocked(glob)
+
+const mockedGetBooleanInput = jest.mocked(getBooleanInput)
+
+describe('checkFileExistence', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  test('calls getBooleanInput with correct input names', async () => {
+    mockedGlob.mockImplementation((_pattern, _options, callback) => {
+      callback(null, ['file1'])
+      return {} as ReturnType<typeof glob>
+    })
+
+    await checkFileExistence('some-pattern')
+
+    expect(mockedGetBooleanInput).toHaveBeenCalledWith(Inputs.NO_CASE)
+    expect(mockedGetBooleanInput).toHaveBeenCalledWith(Inputs.FOLLOW)
+  })
+
+  test('resolves to true when glob finds files', async () => {
+    mockedGlob.mockImplementation((_pattern, _options, callback) => {
+      callback(null, ['file1'])
+      return {} as ReturnType<typeof glob>
+    })
+
+    const result = await checkFileExistence('some-pattern')
+
+    expect(result).toBe(true)
+  })
+
+  test('resolves to false when glob finds no files', async () => {
+    mockedGlob.mockImplementation((_pattern, _options, callback) => {
+      callback(null, [])
+      return {} as ReturnType<typeof glob>
+    })
+
+    const result = await checkFileExistence('some-pattern')
+
+    expect(result).toBe(false)
+  })
+
+  test('rejects when glob returns an error', async () => {
+    const error = new Error('glob_error')
+
+    mockedGlob.mockImplementation((_pattern, _options, callback) => {
+      callback(error, [])
+      return {} as ReturnType<typeof glob>
+    })
+
+    await expect(checkFileExistence('some-pattern')).rejects.toThrow(
+      'glob_error',
+    )
+  })
+
+  test('passes nocase and follow options from getBooleanInput to glob', async () => {
+    mockedGetBooleanInput.mockReturnValueOnce(true).mockReturnValueOnce(false)
+
+    mockedGlob.mockImplementation((_pattern, options, callback) => {
+      callback(null, [])
+      return {} as ReturnType<typeof glob>
+    })
+
+    await checkFileExistence('some-pattern')
+
+    expect(mockedGlob).toHaveBeenCalledWith(
+      'some-pattern',
+      { nocase: true, follow: false },
+      expect.any(Function),
+    )
+  })
+})
 
 describe('globResolution', () => {
   test('calls correct method with true if files array is not empty', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,7 +31,6 @@
     "src/**/*.ts"
   ],
   "exclude": [
-    "node_modules",
-    "**/*.test.ts"
+    "node_modules"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,9 @@
   "compilerOptions": {
     "target": "ES2015",
     "module": "esnext",
-    "lib": ["esnext"],
+    "lib": [
+      "esnext"
+    ],
     "moduleResolution": "node",
     "strict": true,
     "allowJs": true,
@@ -17,10 +19,19 @@
     "outDir": "./dist",
     "tsBuildInfoFile": "./.cache/tsconfig.tsbuildinfo",
     "paths": {
-      ".": ["./"],
-      "~/*": ["src/*"]
+      ".": [
+        "./"
+      ],
+      "~/*": [
+        "src/*"
+      ]
     }
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "**/*.test.ts"]
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "**/*.test.ts"
+  ]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## What was done

### Bug fixes
- Fixed `ignore_case` default value in `action.yml` from `false` to `true`, aligning it with the documented behaviour in the README
- Fixed `ignore_case` and `follow_symlinks` default values from YAML booleans to strings, as required by the GitHub Actions input schema
- Fixed typo in `ignore_case` input description

### CI / Infrastructure
- Upgraded `actions/checkout` from `v1` to `v4` and `actions/setup-node` from `v3` to `v4` in all workflows
- Updated Node.js version from `22` to `24` across all workflows to match the `node24` runtime declared in `action.yml`
- Added `yarn build` before `npx release-it` in the `release` script to ensure `dist/` is always up-to-date at release time

### Documentation
- Added a **"Releasing a New Version"** section to the README with step-by-step instructions for the local release process, including build, `yarn release`, and optional major tag update
- Added troubleshooting note for the `No upstream configured for current branch` error
- Replaced hardcoded `@v1` references in README examples with `@vX.X.X` placeholder

### Tests
- Added 5 missing unit tests for `checkFileExistence`, which previously had no coverage:
  - `getBooleanInput` called with correct input names (`Inputs.NO_CASE`, `Inputs.FOLLOW`)
  - Resolves `true`/`false` based on glob results
  - Rejects on glob error
  - `nocase` and `follow` options correctly forwarded to glob

### Config
- Removed `**/*.test.ts` from `tsconfig.json` `exclude` so the TypeScript language server correctly resolves the `~/*` path alias in test files

Also closes #7 